### PR TITLE
Warnings cleanup re: most stable rust/R, reformatted tests, added mac test info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustr"
 version = "0.1.9"
 authors = ["qinwf <mail@qinwenfeng.com>"]
-include = ["src/**/*", "Cargo.toml","build.rs", "tests/**/*","examples/**/*"]
+include = ["/src/**/*", "/Cargo.toml","/build.rs", "/tests/**/*","/examples/**/*"]
 keywords = ["ffi", "r", "statistic","binding", "math"]
 license = "Apache-2.0"
 description = "Rust and R integration"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,12 +30,12 @@ install:
 environment:
   matrix:
 
-  - R_VERSION: devel
+  - R_VERSION: stable
     R_ARCH: i386
     GCC_PATH: mingw_32
     channel: nightly
 
-  - R_VERSION: devel
+  - R_VERSION: stable
     R_ARCH: x64
     GCC_PATH: mingw_64
     channel: nightly
@@ -43,7 +43,7 @@ environment:
 build_script:
   - cp ../travis-tool.sh travis-tool.sh
   - travis-tool.sh.cmd install_github rustr/rustinr
-  
+
 test_script:
   # - cargo build --features "date engine random logging"
   # - cargo test --verbose --features "date engine random logging"
@@ -54,7 +54,7 @@ test_script:
   - cargo test --features "engine"
 
 on_failure:
-  - cd rtest 
+  - cd rtest
   - ../travis-tool.sh.cmd dump_logs
   - 7z a failure.zip *.Rcheck\*
   - appveyor PushArtifact failure.zip

--- a/examples/engine.rs
+++ b/examples/engine.rs
@@ -1,8 +1,6 @@
 extern crate rustr;
 
 #[cfg(feature = "engine")]
-use rustr::*;
-#[cfg(feature = "engine")]
 use rustr::feature::engine::*;
 
 #[cfg(feature = "engine")]

--- a/src/feature/engine.rs
+++ b/src/feature/engine.rs
@@ -11,7 +11,9 @@ use dll::*;
 use traits::*;
 use error::REKind::*;
 
+#[allow(non_upper_case_globals)]
 pub static mut REng: bool = true;
+#[allow(non_upper_case_globals)]
 pub static mut REngInit: bool = false;
 
 pub struct REngine {

--- a/src/grow.rs
+++ b/src/grow.rs
@@ -8,7 +8,6 @@ use error::*;
 use protect::stackp::*;
 use rtype::*;
 use util::rprint as rp;
-use storage::*;
 
 pub fn pairlist(xs: &[&Args]) -> RResult<SEXP> {
     let mut res: Shield = Shield::new(unsafe { R_NilValue });

--- a/src/rtype.rs
+++ b/src/rtype.rs
@@ -7,6 +7,7 @@ use rdll::{TYPEOF, SEXP, SET_TYPEOF};
 
 pub type Rtype = ::std::os::raw::c_uint;
 
+#[allow(unused_doc_comment)]
 #[derive(Copy, PartialEq, Eq, Clone, Debug)]
 pub enum RTypeEnum {
     NIL,
@@ -40,6 +41,7 @@ pub enum RTypeEnum {
     FUN,
 }
 
+#[allow(unused_doc_comment)]
 #[inline]
 pub fn match_rtype(x: Rtype) -> RTypeEnum {
     match x {

--- a/src/traits/attr.rs
+++ b/src/traits/attr.rs
@@ -5,7 +5,6 @@ use storage::*;
 use util::c_str;
 
 use symbol::*;
-use error::*;
 
 pub trait RAttribute : ToSEXP{
     fn get_attr<D: RNew, S: SEXPbucket, EE: Into<SymbolM<S>>>(&self, name: EE) -> RResult<D> {

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -43,6 +43,7 @@ pub trait RSize {
     fn rsize(&self) -> R_xlen_t;
 }
 
+#[allow(non_snake_case)]
 pub trait SetSEXP {
     fn set_s(&mut self, X: SEXP);
 }

--- a/src/traits/rfield.rs
+++ b/src/traits/rfield.rs
@@ -3,7 +3,6 @@ use traits::{ToSEXP, SetSEXP, RNew};
 use protect::stackp::Shield;
 
 use util::c_str;
-use storage::*;
 use error::*;
 
 pub trait RField: ToSEXP+ SetSEXP{

--- a/test_scripts.md
+++ b/test_scripts.md
@@ -10,3 +10,19 @@ export R_HOME=$(Rscript -e "cat(R.home())")
 export PATH=$PATH:"/c/Program Files/R/R-devel/bin/x64"
 
 ```
+
+## Test Mac
+
+If you installed R from `brew cask install r-app` or direct install of application package:
+
+```bash
+env R_HOME=/Library/Frameworks/R.framework/Resources RUST_TEST_THREADS=1 RLIBPATH=/Library/Frameworks/R.framework/Libraries cargo test --features "engine"
+env R_HOME=/Library/Frameworks/R.framework/Resources RUST_BACKTRACE=1 RLIBPATH=/Library/Frameworks/R.framework/Libraries cargo test --features "engine"
+```
+
+If you installed R from `brew install r`, change the version number in the calls below:
+
+```bash
+env RUST_TEST_THREADS=1 R_HOME=/usr/local/Cellar/r/3.4.3/lib/R RLIBPATH=/usr/local/Cellar/r/3.4.3/lib/ cargo test --features "engine"
+env RUST_BACKTRACE=1 R_HOME=/usr/local/Cellar/r/3.4.3/lib/R RLIBPATH=/usr/local/Cellar/r/3.4.3/lib/ cargo test --features "engine"
+```

--- a/tests/libtests-engine.rs
+++ b/tests/libtests-engine.rs
@@ -6,28 +6,26 @@ pub use rustr::*;
 pub use rustr::feature::engine::*;
 
 #[cfg(all(feature = "engine"))]
-mod rengine{
-	use super::*;
+mod rengine {
+    use super::*;
 
-#[test]
-fn init_eng() {
-   let mut re = unsafe{ REngine::init().unwrap() };
-   let res: f64 = re.eval("1+1").unwrap();
-   println!("{}", res);
-   assert_eq!(2.0, res);
-}
+    #[test]
+    fn init_eng() {
+        let mut re = unsafe { REngine::init().unwrap() };
+        let res: f64 = re.eval("1+1").unwrap();
+        assert_eq!(2.0, res);
+    }
 
-#[test]
-fn init_second_eng() {
-   let mut re = unsafe{ REngine::init().unwrap() };
-   let res: f64 = re.eval("1+1").unwrap();
-   println!("{}", res);
-   assert_eq!(2.0, res);
-}
+    #[test]
+    fn init_second_eng() {
+        let mut re = unsafe { REngine::init().unwrap() };
+        let res: f64 = re.eval("1+1").unwrap();
+        assert_eq!(2.0, res);
+    }
 
-#[test]
-fn z_eng_leave() {
-   let re = unsafe{ REngine::init().unwrap() };
-	unsafe{re.leave()}
-}
+    #[test]
+    fn z_eng_leave() {
+        let re = unsafe { REngine::init().unwrap() };
+        unsafe { re.leave() }
+    }
 }


### PR DESCRIPTION
@qinwf You'll be happy to know that as part of this PR I tested with R 3.4.3, no errors.

Not sure how comprehensive the tests need to be, but I assume I'd have gotten a linking error if there was a major ABI change.

Cleaned up a bunch of warnings related to non-snake case, unused docstrings, unused includes, capitalized globals, includes being changed in upcoming cargo release.

Documented how to run tests on OSX.

Test results follow:

```
┌─[scottmmjackson][turing][±][sj-cleanup ✓][~/rustr]
└─▪ env RUST_TEST_THREADS=1 R_HOME=/usr/local/Cellar/r/3.4.3/lib/R RLIBPATH=/usr/local/Cellar/r/3.4.3/lib/ cargo test --features "engine"
   Compiling rustr v0.1.9 (file:///Users/scottmmjackson/rustr)
    Finished dev [unoptimized + debuginfo] target(s) in 6.90 secs
     Running target/debug/deps/rustr-101b2d03c74f5a91

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/libtests_engine-4dd29160368a5782

running 3 tests
test rengine::init_eng ... ok
test rengine::init_second_eng ... ok
test rengine::z_eng_leave ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests rustr

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

```
┌─[scottmmjackson][turing][±][sj-cleanup ✓][~/rustr]
└─▪ env R_HOME=/usr/local/Cellar/r/3.4.3/lib/R RLIBPATH=/usr/local/Cellar/r/3.4.3/lib/ cargo test --features "engine"
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running target/debug/deps/rustr-101b2d03c74f5a91

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/libtests_engine-4dd29160368a5782

running 3 tests
R is already initialized
R is already initialized
error: test failed, to rerun pass '--test libtests-engine'
```
I assume this test reflects that we're not quite threadsafe yet, and need to run singlethreaded only for now.


